### PR TITLE
Add Unwrap support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/emicklei/tre
+
+go 1.13

--- a/tracing_error_test.go
+++ b/tracing_error_test.go
@@ -16,7 +16,6 @@ func TestTracingError(t *testing.T) {
 	if got, want := Cause(e).Error(), "fail 1"; got != want {
 		t.Errorf("got %v want %v", got, want)
 	}
-
 }
 
 func propError() error {
@@ -30,10 +29,10 @@ func giveError() error {
 func TestEmptyTracingError(t *testing.T) {
 	e := New(errors.New("empty"), "empty").(*TracingError)
 	ctx := e.LoggingContext()
-	if ctx["err"] != e.cause {
+	if ctx["err"] != e.error {
 		t.Error("err expected")
 	}
-	if ctx["err"] != e.cause {
+	if ctx["err"] != e.error {
 		t.Error("err expected")
 	}
 	if ctx["msg"] != "empty" {

--- a/tracing_error_unwrap_test.go
+++ b/tracing_error_unwrap_test.go
@@ -1,0 +1,38 @@
+package tre
+
+import (
+	"errors"
+	"testing"
+)
+
+type TestStruct struct {
+	Inside
+}
+
+func (t TestStruct) FindMe() string {
+	return "Found"
+}
+
+type Inside interface {
+	error
+}
+
+type Findme interface {
+	FindMe() string
+}
+
+func TestUnWrap(t *testing.T) {
+
+	inner := TestStruct{
+		errors.New("inner"),
+	}
+
+	wrapped := New(New(inner, "wrap"), "outer wrap")
+	var totrack Findme
+	if !errors.As(wrapped, &totrack) {
+		t.Errorf("Was unable to unwrap and detect inner error")
+	}
+	if totrack.FindMe() != "Found" {
+		t.Errorf("Unwrap matched wrong type/item")
+	}
+}


### PR DESCRIPTION
I'd like to add unwrap support so that the 'tre' package plays better with recent additions like `errors.As` and `errors.Unwrap`