### PR TITLE
Add support for object with context information

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,24 @@ func foo(param string) error {
         return tre.New(err,"foo failed", "param", param)
     }
 }
+
+func bar() error {
+    info := map[string]interface{}
+    // ...doing stuff
+    info["some"] = "thing"
+    // ...doing more stuff
+    info["more"] = 2
+    // ...almost done
+    info["done"] = true
+
+    // ...then an issue arises
+    if err != nil {
+        // Answer error containing the full context object as key value pairs
+        return tre.New(err, "bar failed", info)
+    }
+
+    return nil
+}
 ```
 
 (c) 2016, http://ernestmicklei.com. MIT License

--- a/tracing_error.go
+++ b/tracing_error.go
@@ -36,14 +36,16 @@ type tracePoint struct {
 }
 
 func (t tracePoint) printOn(b *bytes.Buffer) {
-	fmt.Fprintf(b, "%s:%d %s:%s", t.filename, t.line, t.function, t.message)
+	fmt.Fprintf(b, "%s:%d %s [%s]", t.filename, t.line, t.function, t.message)
 	for k, v := range t.context {
-		fmt.Fprintf(b, " %s=%v ", k, v)
+		fmt.Fprintf(b, " %s=%v", k, v)
 	}
 }
 
 // New creates a TracingError with a failure message and optional context information.
 // It accepts either an error, a TracingError or nil. If the error is nil then return nil.
+// Context information can either be provided as keys and values (e.g. "key1", value1,
+// "key2", value2, etc) or can be provided as a map[string]interface{} context object.
 func New(err error, msg string, kv ...interface{}) error {
 	if err == nil {
 		return nil
@@ -60,18 +62,28 @@ func New(err error, msg string, kv ...interface{}) error {
 			callTrace: []tracePoint{tp},
 		}
 	}
-	for i := 0; i < len(kv); i += 2 {
-		// handle odd key count
-		if i == len(kv)-1 {
-			break
+	cnt := len(kv)
+	if cnt == 1 {
+		// silently ignore incorrect context objects
+		if ctx, ok := kv[0].(map[string]interface{}); ok {
+			for k, v := range ctx {
+				tp.context[k] = v
+			}
 		}
-		// expect string keys
-		k, ok := kv[i].(string)
-		if !ok {
-			// convert if not
-			k = fmt.Sprintf("%v", kv[i])
+	} else {
+		for i := 0; i < len(kv); i += 2 {
+			// handle odd key count
+			if i == len(kv)-1 {
+				break
+			}
+			// expect string keys
+			k, ok := kv[i].(string)
+			if !ok {
+				// convert if not
+				k = fmt.Sprintf("%v", kv[i])
+			}
+			tp.context[k] = kv[i+1]
 		}
-		tp.context[k] = kv[i+1]
 	}
 	return terror
 }
@@ -102,19 +114,27 @@ func (e TracingError) Error() string {
 }
 
 // LoggingContext collects all data for context aware logging purposes.
-// Fixed keys are {err,err.type,stack} unless the value is empty.
+// Fixed keys are {err,err.type,msg,stack} unless the value is empty.
 func (e TracingError) LoggingContext() map[string]interface{} {
 	ctx := map[string]interface{}{}
+
+	// start with context ; could have reserved keys
+	// context variables can be 'overwritten' by newer contexts
+	for _, each := range e.callTrace {
+		for k, v := range each.context {
+			ctx[k] = v
+		}
+	}
+
 	ctx["err"] = e.error
 	ctx["err.type"] = fmt.Sprintf("%T", e.error)
+	ctx["msg"] = e.callTrace[0].message
 	stack := new(bytes.Buffer)
 	// reverse order
 	for i := len(e.callTrace) - 1; i != -1; i-- {
 		caught := e.callTrace[i]
-		fmt.Fprintf(stack, "\n%s:%d %s [%s] ", caught.filename, caught.line, caught.function, caught.message)
-		for k, v := range caught.context {
-			fmt.Fprintf(stack, "%s=%v ", k, v)
-		}
+		fmt.Fprintln(stack)
+		caught.printOn(stack)
 	}
 	ctx["stack"] = stack.String()
 	return ctx

--- a/tracing_error.go
+++ b/tracing_error.go
@@ -102,7 +102,7 @@ func (e TracingError) Error() string {
 }
 
 // LoggingContext collects all data for context aware logging purposes.
-// Fixed keys are {err,line,func,file,stack} unless the value is empty.
+// Fixed keys are {err,err.type,stack} unless the value is empty.
 func (e TracingError) LoggingContext() map[string]interface{} {
 	ctx := map[string]interface{}{}
 	ctx["err"] = e.error

--- a/tracing_error_test.go
+++ b/tracing_error_test.go
@@ -2,6 +2,9 @@ package tre
 
 import (
 	"errors"
+	"fmt"
+	"regexp"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -11,10 +14,9 @@ func TestTracingErrorString(t *testing.T) {
 	terr := New(err, "msg", "key", "value")
 	suffix := `err=test
 err.type=*errors.errorString
-func=tre.TestTracingErrorString
 key=value
-loc=Users/emicklei/xProjects/tre/tracing_error_test.go:11
 msg=msg
+stack=tracing_error_test.go:14 tre.TestTracingErrorString [msg] key=value
 `
 	if got, want := strings.Contains(flatten(terr.Error()), flatten(suffix)), true; got != want {
 		t.Log(flatten(terr.Error()))
@@ -25,7 +27,9 @@ msg=msg
 
 // remove tabs and newlines and spaces
 func flatten(s string) string {
-	return strings.Replace((strings.Replace(s, "\n", "[n]", -1)), "\t", "[t]", -1)
+	// Remove path from go files in stack (only leaving the base name with extension "tracing_error_test.go")
+	re := regexp.MustCompile(`\[n\]([A-Za-z0-9_-]*\/)+([A-Za-z0-9_-]*\.go)`)
+	return re.ReplaceAllString(strings.Replace((strings.Replace(s, "\n", "[n]", -1)), "\t", "[t]", -1), "$2")
 }
 
 func TestTracingError(t *testing.T) {
@@ -83,6 +87,41 @@ func TestLengthOfLargestMatchingPrefix(t *testing.T) {
 	} {
 		if got, want := lengthOfLargestMatchingPrefix(each.s1, each.s2), each.i; got != want {
 			t.Errorf("got %v want %v", got, want)
+		}
+	}
+}
+
+func TestContextObject(t *testing.T) {
+	ctxIn := map[string]interface{}{
+		"key1": "value1",
+		"key2": 2,
+		"key3": false,
+		"key4": nil,
+	}
+	e := New(errors.New("error"), "with context object", ctxIn).(*TracingError)
+	ctxOut := e.LoggingContext()
+	fmt.Println("Compare want -> got")
+	compareContext(t, ctxIn, ctxOut, false)
+	fmt.Println("Compare got -> want")
+	compareContext(t, ctxOut, ctxIn, true)
+}
+
+// Compare if variables in src are in dst, report error if not.
+// Ignore the known fixed keys.
+func compareContext(t *testing.T, src, dest map[string]interface{}, ignoreKeys bool) {
+	var ignore []string
+	if ignoreKeys {
+		ignore = []string{"err", "err.type", "msg", "stack"}
+	}
+	for k, v := range src {
+		if !slices.Contains(ignore, k) {
+			if value, present := dest[k]; present {
+				if v != value {
+					t.Errorf("var %s expect %v retrieved %v", k, v, value)
+				}
+			} else {
+				t.Errorf("var %s is missing", k)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Instead of providing individual key value pairs allow a context information object (`map[string]interface{}`).